### PR TITLE
Chore/35 lazy loading and next image optimsation

### DIFF
--- a/src/app/past-winners/page.tsx
+++ b/src/app/past-winners/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import pastWinners from '@/data/PastWinners';
 import { H1, H2 } from '@/components/common/Typography';
+
 import Image from 'next/image';
 
 // Parses and properly formats and outputs the data from PastWinners.ts
@@ -57,7 +58,8 @@ function WinnerImage({ image, alt }: { image: string; alt: string }) {
     <Image
       src={image}
       alt={alt}
-      className="h-3/4 w-full rounded-3xl object-cover object-center shadow-lg"
+      layout="fill"
+      className="w-full rounded-3xl object-cover object-center shadow-lg"
     />
   );
 }
@@ -81,7 +83,7 @@ export default function PastWinnersPage() {
       {/* Content Section */}
       <div className="mx-auto flex max-w-screen-2xl flex-grow">
         {/* Section for the date scroller. At the moment, uses a temporary format. */}
-        <aside className="flex-shrink-2 w-full">
+        <aside className="flex-shrink-2 w-[40vw]">
           <ul className="space-y-2">
             {pastWinners.map((year) => (
               <li key={year.year}>
@@ -112,7 +114,7 @@ export default function PastWinnersPage() {
                 <div className="md:w-2/4">
                   <WinnerDetails {...winner} />
                 </div>
-                <div className="md:w-2/4">
+                <div className="relative md:w-2/4">
                   <WinnerImage image={winner.image} alt={winner.teamName} />
                 </div>
               </div>
@@ -126,10 +128,15 @@ export default function PastWinnersPage() {
                   {specialAwards.map((winner, index) => (
                     <div
                       key={index}
-                      className="flex flex-col items-center gap-8"
+                      className="relative flex flex-col items-center gap-8"
                     >
                       <WinnerDetails {...winner} />
-                      <WinnerImage image={winner.image} alt={winner.teamName} />
+                      <div className="relative h-[15vw] w-full">
+                        <WinnerImage
+                          image={winner.image}
+                          alt={winner.teamName}
+                        />
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/src/app/past-winners/page.tsx
+++ b/src/app/past-winners/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import pastWinners from '@/data/PastWinners';
 import { H1, H2 } from '@/components/common/Typography';
+import Image from 'next/image';
 
 // Parses and properly formats and outputs the data from PastWinners.ts
 function WinnerDetails({
@@ -53,7 +54,7 @@ function WinnerDetails({
 // Formats the images provided from the PastWinners.ts import.
 function WinnerImage({ image, alt }: { image: string; alt: string }) {
   return (
-    <img
+    <Image
       src={image}
       alt={alt}
       className="h-3/4 w-full rounded-3xl object-cover object-center shadow-lg"


### PR DESCRIPTION
# Description

## What does this PR do?

This pull request updates images in past winners page to use next Image.

## Context

This pull request was made to improve efficiency when handling images.

# Changes 

- Changed img to next Image

# Related Issues 

closes #35 

# Additional Notes

- Width of some parent div of images may need to be adjusted after implementing date scroller.