### PR TITLE
Chore: convert the past winners tables into json data

### DIFF
--- a/src/data/PastWinners.json
+++ b/src/data/PastWinners.json
@@ -6,7 +6,7 @@
           {
             "title": "1st",
             "teamName": "Git Kermit",
-            "photo": "image",
+            "photo": "https://drive.google.com/file/d/17wTS8VkDRlayfCAu7yW-uJTFVmJocc5O/view?usp=sharing",
             "teamMembers": [
               "Cory Brown",
               "Kevin Cao",
@@ -29,7 +29,7 @@
           {
             "title": "2nd",
             "teamName": "Java Skunk",
-            "photo": "image",
+            "photo": "https://drive.google.com/file/d/1Xz_kb_48ng3kq-ytXFekiCQzhria9WS-/view?usp=sharing",
             "teamMembers": [
               "Jason Huang",
               "Chris Valenzuela",
@@ -52,7 +52,7 @@
           {
             "title": "3rd",
             "teamName": "Kappachungus",
-            "photo": "image",
+            "photo": "https://drive.google.com/drive/u/0/folders/1wxWjkKRM-Da83XMXYS6RjyVDHZLY0uCD",
             "teamMembers": [
               "Ryan Yoon",
               "Joshua Morley",
@@ -75,7 +75,7 @@
           {
             "title": "Most Overengineered",
             "teamName": "Exception Handlers",
-            "photo": "image",
+            "photo": "https://drive.google.com/file/d/1qnTZhm1SA0YtJAWOPVjAD7w7knD4R3Tl/view?usp=sharing",
             "teamMembers": [
               "Aref Osman",
               "Alex Brown",
@@ -98,7 +98,7 @@
           {
             "title": "Best Design",
             "teamName": "Git Kermit",
-            "photo": "image",
+            "photo": "https://drive.google.com/file/d/1JZ3q3rcBanW4miQBIO7hgzcLxWv78oN7/view?usp=sharing",
             "teamMembers": [
               "Cory Brown",
               "Kevin Cao",
@@ -121,7 +121,7 @@
           {
             "title": "Most Entertaining",
             "teamName": "print(“hello world”)",
-            "photo": "image",
+            "photo": "https://drive.google.com/file/d/1De7XEsQujk_3farFEHBuUcTVDuptUA7d/view?usp=sharing",
             "teamMembers": [
               "Andre Camerino",
               "Evan Au",
@@ -149,7 +149,7 @@
           {
             "title": "1st",
             "teamName": ":)",
-            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "photo": "https://drive.google.com/file/d/1Mp0397oYXP_euKEHlHrW_7qwUf4StQSw/view",
             "teamMembers": [
               "Raymond Luo",
               "Tony Lu",
@@ -173,7 +173,7 @@
           {
             "title": "2nd",
             "teamName": "Hackathon Smashers",
-            "photo": "WDCC_SESA_HACKATHON_2023_IMG0762.jpg",
+            "photo": "https://drive.google.com/file/d/1P9NFAqoaHkKzV1MQ-t6t1pDNItS4Kjrh/view",
             "teamMembers": [
               "Kian Merchant",
               "Vadim Berezin",
@@ -195,7 +195,7 @@
           {
             "title": "3rd",
             "teamName": "Hackathon Smackathon",
-            "photo": "WDCC_SESA_HACKATHON_2023_IMG0759.jpg",
+            "photo": "https://drive.google.com/file/d/1WfdIv4wfYoggTKrcakgWaM17o-_UjtMM/view",
             "teamMembers": [
               "Matthew Tao",
               "Jack Freeth",
@@ -219,7 +219,7 @@
           {
             "title": "Most Overengineered",
             "teamName": "Tron",
-            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "photo": "https://drive.google.com/file/d/1XgympL1QyAkspp3-snyG9iSRj2lau_dn/view",
             "teamMembers": [
               "James Zeng",
               "Celine Bui",
@@ -241,7 +241,7 @@
           {
             "title": "Best Design",
             "teamName": "Pro (?) Hackers",
-            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "photo": "https://drive.google.com/file/d/1fi036IjEDxlSeDXo8aFCmPuXKJ43DJoF/view",
             "teamMembers": [
               "Arvindh Kumar",
               "Enrique Jugo",
@@ -263,7 +263,7 @@
           {
             "title": "Most Entertaining",
             "teamName": "Compsisters",
-            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "photo": "https://drive.google.com/file/d/1Y6an5xY2io8ST6ebRCIY2dYEzXePP-jE/view",
             "teamMembers": [
               "Cheryl Yu",
               "Puja Nory",
@@ -408,7 +408,7 @@
           {
             "title": "1st",
             "teamName": "Dumboss",
-            "photo": "HACKATHON-181.jpg",
+            "photo": "https://drive.google.com/file/d/1djdzavHLnwkj-A-jhHk5oQx8P6C3WHVI/view",
             "teamMembers": [
               "Beverley Sun",
               "Matt Moran",
@@ -427,7 +427,7 @@
           {
             "title": "2nd",
             "teamName": "BitGud",
-            "photo": "HACKATHON-183.jpg",
+            "photo": "https://drive.google.com/file/d/1-JNhgbDjxwr9CWxFI18ddGbj018QRB9s/view",
             "teamMembers": [
               "Bob Liou",
               "Taylor Tran",
@@ -450,7 +450,7 @@
           {
             "title": "3rd",
             "teamName": "Krayon",
-            "photo": "HACKATHON-179.jpg",
+            "photo": "https://drive.google.com/file/d/1vuCuTf-t3Ns6Lo4r_B0eNbu6hX767Efl/view",
             "teamMembers": [
               "Ryan Tan",
               "Sunny Feng",
@@ -470,7 +470,7 @@
           {
             "title": "Most Overengineered",
             "teamName": "Diskordo",
-            "photo": "HACKATHON-182.jpg",
+            "photo": "https://drive.google.com/file/d/1Gt1rx9rCMxZ7RQzEX3wK6r5_hSp93PdX/view",
             "teamMembers": [
               "Jennifer Lowe",
               "Hiruna Jayamanne",
@@ -491,7 +491,7 @@
           {
             "title": "Best Design",
             "teamName": "MeowMeowMeow",
-            "photo": "HACKATHON-184.jpg",
+            "photo": "https://drive.google.com/file/d/1JOuoZf-R44fYKJgxmo8cGxAF_ubrvVqs/view",
             "teamMembers": [
               "Jack Ma",
               "Rhys Heaven-Smith",

--- a/src/data/PastWinners.json
+++ b/src/data/PastWinners.json
@@ -1,0 +1,520 @@
+{
+    "pastWinners": [
+      {
+        "year": 2024,
+        "awards": [
+          {
+            "title": "1st",
+            "teamName": "Git Kermit",
+            "photo": "image",
+            "teamMembers": [
+              "Cory Brown",
+              "Kevin Cao",
+              "Shuhei Yokkaichi",
+              "Samuel Chung",
+              "Jessica Zeng",
+              "Chris Oliver"
+            ],
+            "contacts": [
+              "Cbro223@aucklanduni.ac.nz",
+              "kcao657@aucklanduni.ac.nz",
+              "Syok443@aucklanduni.ac.nz",
+              "schu718@aucklanduni.ac.nz",
+              "Szen566@aucklanduni.ac.nz",
+              "Coli772@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "2nd",
+            "teamName": "Java Skunk",
+            "photo": "image",
+            "teamMembers": [
+              "Jason Huang",
+              "Chris Valenzuela",
+              "Kinzi Ceolin",
+              "Siyeon Kim",
+              "Xin Yue",
+              "Skyler Solomon-Gavin"
+            ],
+            "contacts": [
+              "jhua540@aucklanduni.ac.nz",
+              "cval893@aucklanduni.ac.nz",
+              "kceo161@aucklanduni.ac.nz",
+              "skim411@aucklanduni.ac.nz",
+              "xyue918@aucklanduni.ac.nz",
+              "ssol696@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "3rd",
+            "teamName": "Kappachungus",
+            "photo": "image",
+            "teamMembers": [
+              "Ryan Yoon",
+              "Joshua Morley",
+              "Ray Xiao",
+              "Katie Zhou",
+              "Connor Williams",
+              "Jaap Skinner"
+            ],
+            "contacts": [
+              "ryoo514@aucklanduni.ac.nz",
+              "jmor490@aucklanduni.ac.nz",
+              "rxia357@aucklanduni.ac.nz",
+              "kzho904@aucklanduni.ac.nz",
+              "cwil915@aucklanduni.ac.nz",
+              "jski306@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Most Overengineered",
+            "teamName": "Exception Handlers",
+            "photo": "image",
+            "teamMembers": [
+              "Aref Osman",
+              "Alex Brown",
+              "Brandon Seng Han Chan",
+              "Daniel Munn",
+              "Henry Ly",
+              "James Tasker"
+            ],
+            "contacts": [
+              "aosm976@aucklanduni.ac.nz",
+              "abro522@aucklanduni.ac.nz",
+              "bcha389@aucklanduni.ac.nz",
+              "dmun793@aucklanduni.ac.nz",
+              "hly852@aucklanduni.ac.nz",
+              "jtas575@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Best Design",
+            "teamName": "Git Kermit",
+            "photo": "image",
+            "teamMembers": [
+              "Cory Brown",
+              "Kevin Cao",
+              "Shuhei Yokkaichi",
+              "Samuel Chung",
+              "Jessica Zeng",
+              "Chris Oliver"
+            ],
+            "contacts": [
+              "Cbro223@aucklanduni.ac.nz",
+              "kcao657@aucklanduni.ac.nz",
+              "Syok443@aucklanduni.ac.nz",
+              "schu718@aucklanduni.ac.nz",
+              "Szen566@aucklanduni.ac.nz",
+              "Coli772@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Most Entertaining",
+            "teamName": "print(“hello world”)",
+            "photo": "image",
+            "teamMembers": [
+              "Andre Camerino",
+              "Evan Au",
+              "Luase Fontaine",
+              "Ashlee Shum",
+              "Gabrielle Esguerra",
+              "Jayden Newport"
+            ],
+            "contacts": [
+              "rcam301@aucklanduni.ac.nz",
+              "eau465@aucklanduni.ac.nz",
+              "lfon434@aucklanduni.ac.nz",
+              "ashlee@shum.co.nz",
+              "esguerra.gabrielle12@gmail.com",
+              "jtnew.king@gmail.com"
+            ],
+            "github": "",
+            "deployedProject": ""
+          }
+        ]
+      },
+      {
+        "year": 2023,
+        "awards": [
+          {
+            "title": "1st",
+            "teamName": ":)",
+            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "teamMembers": [
+              "Raymond Luo",
+              "Tony Lu",
+              "Ashin Alex",
+              "Raymond Yang",
+              "Selin Akkaya",
+              "Arnav Shekaran"
+            ],
+            "projectDescription": "The Art Thief” where the user uses stable diffusion to create replicas of famous art.",
+            "contacts": [
+              "rluo154@aucklanduni.ac.nz",
+              "tlu467@aucklanduni.ac.nz",
+              "ashinalex1@gmail.com",
+              "rshe412@aucklanduni.ac.nz",
+              "Selinakkaya345@gmail.com",
+              "arnard76@gmail.com"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "2nd",
+            "teamName": "Hackathon Smashers",
+            "photo": "WDCC_SESA_HACKATHON_2023_IMG0762.jpg",
+            "teamMembers": [
+              "Kian Merchant",
+              "Vadim Berezin",
+              "Woo Jin Lee",
+              "Sebastian Thomas",
+              "Don Sheng Qiang Lin"
+            ],
+            "projectDescription": "Text to grunt translator",
+            "contacts": [
+              "supesu.dev@gmail.com",
+              "vdaberezin@gmail.com",
+              "wlee447@aucklanduni.ac.nz",
+              "stho382@aucklanduni.ac.nz",
+              "dlin419@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "3rd",
+            "teamName": "Hackathon Smackathon",
+            "photo": "WDCC_SESA_HACKATHON_2023_IMG0759.jpg",
+            "teamMembers": [
+              "Matthew Tao",
+              "Jack Freeth",
+              "Matthew Taylor",
+              "Alex McLeod",
+              "Varshini KP Bhat",
+              "Henry Wang"
+            ],
+            "projectDescription": "LinkedIn with families and classes and marriages",
+            "contacts": [
+              "ytao543@aucklanduni.ac.nz",
+              "jfre479@aucklanduni.ac.nz",
+              "matthew.taylor@auckland.ac.nz",
+              "amcl287@aucklanduni.ac.nz",
+              "vbha515@aucklanduni.ac.nz",
+              "hwan513@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Most Overengineered",
+            "teamName": "Tron",
+            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "teamMembers": [
+              "James Zeng",
+              "Celine Bui",
+              "Caleb Wedgwood",
+              "Caleb Mackle",
+              "Ronak Lal"
+            ],
+            "projectDescription": "Chariot horse parking simulator.",
+            "contacts": [
+              "jzen379@aucklanduni.ac.nz",
+              "gbui042@aucklanduni.ac.nz",
+              "cwed105@aucklanduni.ac.nz",
+              "cmac558@aucklanduni.ac.nz",
+              "ronak.lal@outlook.com"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Best Design",
+            "teamName": "Pro (?) Hackers",
+            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "teamMembers": [
+              "Arvindh Kumar",
+              "Enrique Jugo",
+              "Peter Cheong",
+              "Deven Ranchhod",
+              "Lachlan Chan"
+            ],
+            "projectDescription": "Graphic novel game thing - pick a path story",
+            "contacts": [
+              "aram190@aucklanduni.ac.nz",
+              "juanenriquejugo@gmail.com",
+              "pche314@aucklanduni.ac.nz",
+              "dran794@aucklanduni.ac.nz",
+              "lcha691@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Most Entertaining",
+            "teamName": "Compsisters",
+            "photo": "WDCC_SESA_HACKATHON_2023_IMG0767.jpg",
+            "teamMembers": [
+              "Cheryl Yu",
+              "Puja Nory",
+              "Hira Saleem",
+              "Kimberly Zhu",
+              "Arisa Mori"
+            ],
+            "projectDescription": "App letting kings pick out their wives for each night",
+            "contacts": [
+              "cyu880@aucklanduni.ac.nz",
+              "pnor067@aucklanduni.ac.nz",
+              "hsal869@aucklanduni.ac.nz",
+              "kzhu796@aucklanduni.ac.nz",
+              "amor401@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          }
+        ]
+      },
+      {
+        "year": 2022,
+        "awards": [
+          {
+            "title": "1st",
+            "teamName": "Lubricated Ducks",
+            "photo": "https://drive.google.com/file/d/1GAFMTG1bbFspFGEHfj-0uHNIwl2r2sKm/view?usp=drive_link",
+            "teamMembers": [
+              "Ron Bansal",
+              "Grant Liu",
+              "Jimmy Wang",
+              "Jay Prasad",
+              "Vishva Dave",
+              "Harry Qu"
+            ],
+            "contacts": [
+              "raunaqbansal@hotmail.com",
+              "gliu871@aucklanduni.ac.nz",
+              "jimwang6012@gmail.com",
+              "Jayprasad770@gmail.com",
+              "vdav604@aucklanduni.ac.nz",
+              "Harryqu666@gmail.com"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "2nd",
+            "teamName": "Jade Jaguars",
+            "photo": "https://drive.google.com/drive/u/0/folders/1gOBOPrkT1J_Sbo3BND6_kIaTCVvCWvcR",
+            "teamMembers": [
+              "Danielle Print",
+              "Andreas Knapp",
+              "Samuel Chen",
+              "Etienne Naude",
+              "Raina Song",
+              "Jessica Villegas"
+            ],
+            "contacts": [
+              "dpri537@aucklanduni.ac.nz",
+              "akna890@aucklanduni.ac.nz",
+              "jche580@aucklanduni.ac.nz",
+              "enau831@aucklanduni.ac.nz",
+              "yson590@aucklanduni.ac.nz",
+              "jvil373@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "3rd",
+            "teamName": "Team X",
+            "photo": "https://drive.google.com/drive/u/0/folders/1gOBOPrkT1J_Sbo3BND6_kIaTCVvCWvcR",
+            "teamMembers": [
+              "Jared Daniel Recomenable",
+              "Zoe Niu",
+              "Avikash Naidu",
+              "Cale Ying",
+              "Aden Ing",
+              "Dhruv Joshi"
+            ],
+            "contacts": [
+              "jrec291@aucklanduni.ac.nz",
+              "zniu202@aucklanduni.ac.nz",
+              "anai393@aucklanduni.ac.nz",
+              "cale.ying@gmail.com",
+              "aing810@aucklanduni.ac.nz",
+              "djdhruvmj@gmail.com"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Most Overengineered",
+            "teamName": "Andrew's Angular Team",
+            "photo": "https://drive.google.com/drive/u/0/folders/1gOBOPrkT1J_Sbo3BND6_kIaTCVvCWvcR",
+            "teamMembers": [
+              "Jiaru Lin",
+              "Cheng-Zhen Yang",
+              "Flynn Fromont",
+              "Hiruna Jayamanne",
+              "Bob Liou"
+            ],
+            "contacts": [
+              "jlin296@aucklanduni.ac.nz",
+              "cyan562@aucklanduni.ac.nz",
+              "flynn.fromont@gmail.com",
+              "hjay473@aucklanduni.ac.nz",
+              "bob7689@gmail.com"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Best Design",
+            "teamName": "Infinity^2",
+            "photo": "https://drive.google.com/drive/u/0/folders/1gOBOPrkT1J_Sbo3BND6_kIaTCVvCWvcR",
+            "teamMembers": [
+              "Lia Arroyo",
+              "Eugene Chua",
+              "Amisha Singh",
+              "Caitlin Pillay",
+              "Vanisha Rajan",
+              "Bun Thong Chea"
+            ],
+            "contacts": [
+              "marr341@aucklanduni.ac.nz",
+              "echu192@aucklanduni.ac.nz",
+              "asin448@aucklanduni.ac.nz",
+              "cpil393@aucklanduni.ac.nz",
+              "vraj752@aucklanduni.ac.nz",
+              "tche206@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          }
+        ]
+      },
+      {
+        "year": 2021,
+        "awards": [
+          {
+            "title": "1st",
+            "teamName": "Dumboss",
+            "photo": "HACKATHON-181.jpg",
+            "teamMembers": [
+              "Beverley Sun",
+              "Matt Moran",
+              "Maggie Pedersen",
+              "Raina Song"
+            ],
+            "contacts": [
+              "bsun448@aucklanduni.ac.nz",
+              "mmor330@aucklanduni.ac.nz",
+              "mped822@aucklanduni.ac.nz",
+              "yson590@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "2nd",
+            "teamName": "BitGud",
+            "photo": "HACKATHON-183.jpg",
+            "teamMembers": [
+              "Bob Liou",
+              "Taylor Tran",
+              "Cheng-Zhen Yang",
+              "Patricia Virgen Aguilar",
+              "Libby Cammell",
+              "Alexander Bailey"
+            ],
+            "contacts": [
+              "bob7689@gmail.com",
+              "taylortran.it@gmail.com",
+              "chengzhenyang@gmail.com",
+              "patriciavirgenaguilar@hotmail.com",
+              "elizabeth.cammell88@gmail.com",
+              "abai250@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "3rd",
+            "teamName": "Krayon",
+            "photo": "HACKATHON-179.jpg",
+            "teamMembers": [
+              "Ryan Tan",
+              "Sunny Feng",
+              "Kimberley Evans-Parker",
+              "Josh Hill",
+              "Kelvin Ngor"
+            ],
+            "contacts": [
+              "rtan265@aucklanduni.ac.nz",
+              "sfen917@aucklanduni.ac.nz",
+              "keva419@aucklanduni.ac.nz",
+              "jhil955@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Most Overengineered",
+            "teamName": "Diskordo",
+            "photo": "HACKATHON-182.jpg",
+            "teamMembers": [
+              "Jennifer Lowe",
+              "Hiruna Jayamanne",
+              "Tianren Shen",
+              "Elisa Yansun",
+              "Linda Lin"
+            ],
+            "contacts": [
+              "jenniferlowe7@LIVE.com",
+              "hjay473@aucklanduni.ac.nz",
+              "tshe695@aucklanduni.ac.nz",
+              "eyan868@aucklanduni.ac.nz",
+              "clin802@aucklanduni.ac.nz"
+            ],
+            "github": "",
+            "deployedProject": ""
+          },
+          {
+            "title": "Best Design",
+            "teamName": "MeowMeowMeow",
+            "photo": "HACKATHON-184.jpg",
+            "teamMembers": [
+              "Jack Ma",
+              "Rhys Heaven-Smith",
+              "Feras Albaroudi",
+              "Katherine Luo",
+              "Samuel Chen",
+              "Xinning Gong",
+              "Shirley Shao"
+            ],
+            "contacts": [
+              "924756831@qq.com",
+              "rhysheavensmith@gmail.com",
+              "falb418@aucklanduni.ac.nz",
+              "1019luo@gmail.com",
+              "jche580@aucklanduni.ac.nz",
+              "Xinning.gong@gmail.com",
+              "hyshao615@gmail.com"
+            ],
+            "github": "",
+            "deployedProject": ""
+          }
+        ]
+      }
+    ]
+  }
+  


### PR DESCRIPTION
This pull request adds information about past hackathon winners (2021–2024), including team names, awards, photos, members, and contact details.

Key Changes
- Organised winners by year and award categories (e.g., "1st Place," "Best Design").
- Included photos, team member names, and contact emails.

This update provides a comprehensive archive of hackathon achievements.






